### PR TITLE
Donate button on Support page link amended

### DIFF
--- a/src/templates/support/index.hbs
+++ b/src/templates/support/index.hbs
@@ -58,7 +58,7 @@
         <div class="text">
           <h2>Donate Online</h2>
           <p>Red Dust urgently needs your support to break the cycle of poor health so that this generation of Indigenous youth in remote communities has a healthier future. Without your help, there is only a remote chance we can break the cycle.</p>
-          <a href="http://reddust.gofundraise.com.au/" class="button">Donate</a>
+          <a href="https://heroix-au.everydayhero.com/charities/871/donate" class="button">Donate</a>
         </div>
       </div>
     </section>


### PR DESCRIPTION
It's just a single link on a single page, I checked through the site and there are no other references to this specific donate link